### PR TITLE
Added 'parameter file' functionality.

### DIFF
--- a/build.py
+++ b/build.py
@@ -137,11 +137,11 @@ def build():
   sys.exit()
 
 if len(sys.argv) != 2:
-  print 'ERROR: Format is'
-  print '  python build.py [model]'
+  print('ERROR: Format is')
+  print('  python build.py [model]')
   sys.exit()
 if (not os.path.isfile('model/' + sys.argv[1] + '.c')):
-  print 'ERROR Model %s does not exist' % sys.argv[1]
+  print('ERROR Model %s does not exist' % sys.argv[1])
   sys.exit()
 
 import shutil

--- a/decs.h
+++ b/decs.h
@@ -18,6 +18,7 @@
 #include <time.h>
 #include "constants.h"
 #include "model.h"
+#include "par.h"
 
 #define NUCUT (1.e14)
 
@@ -174,7 +175,7 @@ extern double max_tau_scatt, Ladv, dMact, bias_norm;
 /* core monte carlo/radiative transport routines */
 void track_super_photon(struct of_photon *ph);
 void record_super_photon(struct of_photon *ph);
-void report_spectrum(int N_superph_made);
+void report_spectrum(int N_superph_made, Params *params);
 void scatter_super_photon(struct of_photon *ph, struct of_photon *php,
   double Ne, double Thetae, double B, double Ucon[NDIM], double Bcon[NDIM],
   double Gcov[NDIM][NDIM]);
@@ -258,7 +259,7 @@ void sample_scattered_photon(double k[NDIM], double p[NDIM],
    basic interfaces define the model **/
 
 /* physics related */
-void init_model(int argc, char *argv[]);
+void init_model(int argc, char *argv[], Params *params);
 void make_super_photon(struct of_photon *ph, int *quit_flag);
 double bias_func(double Te, double w);
 void get_fluid_params(double X[NDIM], double gcov[NDIM][NDIM], double *Ne,
@@ -278,7 +279,7 @@ void bl_coord(double *X, double *r, double *th);
 void make_zone_centered_tetrads(void);
 void set_units(char *munitstr);
 void init_geometry(void);
-void init_data(int argc, char *argv[]);
+void init_data(int argc, char *argv[], Params *params);
 void init_nint_table(void);
 void init_storage(void);
 //double dOmega_func(double Xi[NDIM], double Xf[NDIM]);

--- a/main.c
+++ b/main.c
@@ -42,6 +42,7 @@
 #include "decs.h"
 
 /* defining declarations for global variables */
+Params params = { 0 };
 struct of_geom **geom;
 int nthreads;
 int N1, N2, N3, n_within_horizon;
@@ -65,23 +66,25 @@ int main(int argc, char *argv[])
 {
   //omp_set_num_threads(1);
   double N_superph_made;
-  //int quit_flag;
-  //struct of_photon ph;
   time_t currtime, starttime;
-
-  report_bad_input(argc);
 
   // Spectral bin parameters
   dlE = 0.25;   // bin width
   lE0 = log(1.e-12);  // location of first bin, in electron rest-mass units
 
-  init_model(argc, argv);
+  // Load parameters
+  for (int i=0; i<argc-1; ++i) {
+    if ( strcmp(argv[i], "-par") == 0 ) {
+      load_par(argv[i+1], &params);
+    }
+  }
+
+  init_model(argc, argv, &params);
 
   N_superph_made = 0;
   N_superph_recorded = 0;
   N_scatt = 0;
   starttime = time(NULL);
-  //quit_flag = 0;
 
   printf("SYNCH: %i\n", SYNCHROTRON);
   printf("BREMS: %i\n", BREMSSTRAHLUNG);
@@ -139,7 +142,7 @@ int main(int argc, char *argv[])
 
   omp_reduce_spect();
 
-  report_spectrum((int) N_superph_made);
+  report_spectrum((int) N_superph_made, &params);
 
   return 0;
 }

--- a/model/bhlight2d.c
+++ b/model/bhlight2d.c
@@ -440,7 +440,7 @@ double dOmega_func(int j)
 }
 
 //////////////////////////////// INITIALIZATION ////////////////////////////////
-void init_data(int argc, char *argv[])
+void init_data(int argc, char *argv[], Params *params)
 {
   FILE *fp;
   double x[NDIM];
@@ -453,8 +453,16 @@ void init_data(int argc, char *argv[])
   double Ucon[NDIM], Ucov[NDIM], Bcon[NDIM], Bcov[NDIM];
   //double J;
 
-  char *fname = argv[2];
+  const char *fname = NULL;
+
+  if (params->loaded && strlen(params->dump) > 0) {
+    fname = params->dump;
+  } else {
+    fname = argv[2];
+  }
+
   fp = fopen(fname, "r");
+
   if (fp == NULL) {
     fprintf(stderr, "Can't open sim data file %s\n", fname);
     exit(-1);
@@ -634,7 +642,7 @@ void init_data(int argc, char *argv[])
 //////////////////////////////////// OUTPUT ////////////////////////////////////
 
 #define SPECTRUM_FILE_NAME "spectrum.dat"
-void report_spectrum(int N_superph_made)
+void report_spectrum(int N_superph_made, Params *params)
 {
   double dOmega, nuLnu, tau_scatt, L;//, Xi[NDIM], Xf[NDIM];
   FILE *fp;
@@ -642,7 +650,12 @@ void report_spectrum(int N_superph_made)
   double nu0,nu1,nu,fnu ;
   double dsource = 8000*PC ;
 
-  fp = fopen(SPECTRUM_FILE_NAME, "w");
+  if (params->loaded && strlen(params->spectrum) > 0) {
+    fp = fopen(params->spectrum, "w");
+  } else {
+    fp = fopen(SPECTRUM_FILE_NAME, "w");
+  }
+
   if (fp == NULL) {
     fprintf(stderr, "trouble opening spectrum file\n");
     exit(0);

--- a/model/sphere.c
+++ b/model/sphere.c
@@ -389,7 +389,7 @@ double dOmega_func(int j)
 
 //////////////////////////////// INITIALIZATION ////////////////////////////////
 
-void init_data(int argc, char *argv[])
+void init_data(int argc, char *argv[], Params *params)
 {
   double dV, V;
 
@@ -509,7 +509,7 @@ void init_data(int argc, char *argv[])
 //////////////////////////////////// OUTPUT ////////////////////////////////////
 
 #define SPECTRUM_FILE_NAME "spectrum.dat"
-void report_spectrum(int N_superph_made)
+void report_spectrum(int N_superph_made, Params *params)
 {
   double dOmega, nuLnu, tau_scatt, L;//, Xi[NDIM], Xf[NDIM];
   FILE *fp;
@@ -517,7 +517,12 @@ void report_spectrum(int N_superph_made)
   double nu0,nu1,nu,fnu ;
   double dsource = 8000*PC ;
 
-  fp = fopen(SPECTRUM_FILE_NAME, "w");
+  if (params->loaded && strlen(params->spectrum) > 0) {
+    fp = fopen(params->spectrum, "w");
+  } else {
+    fp = fopen(SPECTRUM_FILE_NAME, "w");
+  }
+
   if (fp == NULL) {
     fprintf(stderr, "trouble opening spectrum file\n");
     exit(0);

--- a/par.c
+++ b/par.c
@@ -1,0 +1,66 @@
+
+#include "par.h"
+
+// sets default values for elements of params (if desired) and loads
+// from par file 'fname'
+void load_par (const char *fname, Params *params) {
+ 
+  char line[256];
+  FILE *fp = fopen(fname, "r");
+
+  if (fp == NULL) {
+    fprintf(stderr, "! unable to load parameter file '%s'. (%d: %s)\n", fname, errno, strerror(errno));
+    exit(errno);
+  }
+
+  // set default values here
+  params->TP_OVER_TE = 3.;
+
+  // modify parameters/types below
+  while (fgets(line, 255, fp) != NULL) {
+
+    if (line[0] == '#') continue;
+
+    read_param(line, "Ns", &(params->Ns), TYPE_DBL);
+    read_param(line, "MBH", &(params->MBH), TYPE_DBL);
+    read_param(line, "M_unit", &(params->M_unit), TYPE_DBL);
+    read_param(line, "TP_OVER_TE", &(params->TP_OVER_TE), TYPE_DBL);
+
+    read_param(line, "dump", (void *)(params->dump), TYPE_STR);
+    read_param(line, "spectrum", (void *)(params->spectrum), TYPE_STR);
+    
+  }
+
+  fclose(fp);
+
+  params->loaded = 1;
+
+}
+
+// loads value -> (type *)*val if line corresponds to (key,value)
+void read_param (const char *line, const char *key, void *val, int type) {
+
+  char word[256], value[256];
+
+  sscanf(line, "%s %s", word, value);
+
+  if (strcmp(word, key) == 0) {
+    switch (type) {
+    case TYPE_INT:
+      sscanf(value, "%d", (int *)val);
+      break;
+    case TYPE_DBL:
+      sscanf(value, "%lf", (double *)val);
+      break;
+    case TYPE_STR:
+      sscanf(value, "%s", (char *)val);
+      break;
+    default:
+      fprintf(stderr, "! attempt to load unknown type '%d'.\n", type);
+    }
+  }
+
+}
+
+
+

--- a/par.h
+++ b/par.h
@@ -1,0 +1,31 @@
+#ifndef PAR_H
+#define PAR_H
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define TYPE_INT (1)
+#define TYPE_DBL (2)
+#define TYPE_STR (3)
+
+// feel free to change any part of this structure
+typedef struct params_t {
+  double Ns;
+  double MBH;
+  double M_unit;
+  double TP_OVER_TE;
+  const char dump[256];
+  const char spectrum[256];
+  char loaded;
+} Params;
+
+// if you modify the 'parameters' struct above, you'll need to
+// modify this function as well to deal with the changes
+void load_par(const char *, Params *);
+
+// only modify if you add/modify types
+void read_param(const char *, const char *, void *, int);
+
+#endif // PAR_H

--- a/template.par
+++ b/template.par
@@ -1,0 +1,10 @@
+# template parameter file
+
+Ns            100000
+MBH           4.6e+6
+M_unit        1.9e+18
+TP_OVER_TE    3.
+
+dump          dump_00001200.h5
+spectrum      spectrum.dat
+              

--- a/utils.c
+++ b/utils.c
@@ -8,16 +8,26 @@ void get_fluid_zone(int i, int j, int k, double *Ne, double *Thetae, double *B,
 //#define OLD_WGT (1)
 #define OLD_WGT (0)
 
-void init_model(int argc, char *argv[])
+void init_model(int argc, char *argv[], Params *params)
 {
   fprintf(stderr, "getting simulation data...\n");
 
-  double Ntot;
-  sscanf(argv[1], "%lf", &Ntot);
-	Ns = (int) Ntot;
+  if (params->loaded) {
+
+    Ns = (int) params->Ns;
+
+  } else {
+
+    report_bad_input(argc);
+
+    double Ntot;
+    sscanf(argv[1], "%lf", &Ntot);
+	  Ns = (int) Ntot;
+
+  }
 
   // Read dumpfile
-  init_data(argc, argv);
+  init_data(argc, argv, params);
 
   // make look-up table for hot cross sections
   init_hotcross();


### PR DESCRIPTION
In this pull request, I introduce the ability to use command line "parameter files" through use of the -par flag. This feature should not break legacy run scripts. The new syntax is

```shell
$ ./grmonty -par [parfilename]
```

A template parameter file has included with the name ```template.par```.

Loading the parameter file updates a list of internal (global) parameters, stored in the Params struct (defined in ```par.h```). New members can be added to the Params struct by modifying the struct itself and updating the function ```void load_par(...)``` in ```par.c``` accordingly.

The current method used to read parameters is designed for readable and extension, not computational efficiency. Because this function is only runs once, its effect should be negligible.

(Also note ```build.py``` script updated to conform to [python3's print-is-a-function standard](https://docs.python.org/3/whatsnew/3.0.html#print-is-a-function).)
 

