### PR TITLE
hdf5 output for spectrum data

### DIFF
--- a/build.py
+++ b/build.py
@@ -40,7 +40,7 @@ def build():
 
   host = machines.get_machine()
 
-  C_FLAGS = '-std=c99 ' + host['COMPILER_FLAGS']
+  C_FLAGS = '-std=c99 -DVERSION=$(GIT_VERSION) ' + host['COMPILER_FLAGS']
 
   # MATH AND DYNAMIC LINKING
   LIB_FLAGS = '-lm -ldl'
@@ -78,6 +78,7 @@ def build():
 
   # WRITE MAKEFILE
   mf = open('makefile', 'w')
+  mf.write('GIT_VERSION = $(shell git describe --dirty --always --tags)' + '\n')
   mf.write('CC = ' + host['COMPILER'] + '\n')
   mf.write('CCFLAGS = ' + C_FLAGS + ' ' + LIBRARIES + ' ' + INCLUDES + '\n')
   mf.write('LIB_FLAGS = ' + LIB_FLAGS + '\n')

--- a/decs.h
+++ b/decs.h
@@ -142,6 +142,7 @@ extern int N1, N2, N3;
 extern int n_within_horizon;
 
 /* some coordinate parameters */
+extern double t;
 extern double a;
 extern double R0, Rin, Rh, Rout, Rms;
 extern double hslope;
@@ -163,6 +164,8 @@ extern double TP_OVER_TE;
 extern double max_tau_scatt, Ladv, dMact, bias_norm;
 
 // Macros
+#define xstr(s) str(s)
+#define str(s) #s
 #define ZLOOP for (int i = 0; i < N1; i++) \
               for (int j = 0; j < N2; j++) \
               for (int k = 0; k < N3; k++)

--- a/h5io.c
+++ b/h5io.c
@@ -1,0 +1,102 @@
+
+#include "h5io.h"
+
+void h5io_add_group(hid_t fid, const char *path) 
+{
+  hid_t group_id = H5Gcreate2(fid, path, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Gclose(group_id);
+}
+
+void h5io_add_attribute_int(hid_t fid, const char *path, const char *name, int attribute)
+{
+  hid_t dataspace_id = H5Screate(H5S_SCALAR);
+  hid_t attribute_id = H5Acreate_by_name(fid, path, name, H5IO_FMT_INT, H5Screate(H5S_SCALAR), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Awrite(attribute_id, H5T_NATIVE_INT, &attribute);
+  H5Aclose(attribute_id);
+  H5Sclose(dataspace_id);
+}
+
+void h5io_add_attribute_dbl(hid_t fid, const char *path, const char *name, double attribute)
+{
+  hid_t dataspace_id = H5Screate(H5S_SCALAR);
+  hid_t attribute_id = H5Acreate_by_name(fid, path, name, H5IO_FMT_DBL, H5Screate(H5S_SCALAR), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Awrite(attribute_id, H5T_NATIVE_DOUBLE, &attribute);
+  H5Aclose(attribute_id);
+  H5Sclose(dataspace_id);
+}
+
+void h5io_add_attribute_str(hid_t fid, const char *path, const char *name, const char *attribute)
+{ 
+  hid_t dtype_id = H5Tcopy(H5IO_FMT_STR);
+  H5Tset_size(dtype_id, strlen(attribute)+1);
+  H5Tset_strpad(dtype_id, H5T_STR_NULLTERM);
+  hid_t dataspace_id = H5Screate(H5S_SCALAR);
+  hid_t attribute_id = H5Acreate_by_name(fid, path, name, dtype_id, H5Screate(H5S_SCALAR), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Awrite(attribute_id, dtype_id, attribute);
+  H5Aclose(attribute_id);
+  H5Sclose(dataspace_id);
+  H5Tclose(dtype_id);
+}
+
+void h5io_add_data_int(hid_t fid, const char *path, int data) 
+{
+  hid_t dataspace_id = H5Screate(H5S_SCALAR);
+  hid_t dataset_id = H5Dcreate2(fid, path, H5IO_FMT_INT, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Dwrite(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &data);
+  H5Dclose(dataset_id);
+  H5Sclose(dataspace_id);
+}
+
+
+void h5io_add_data_dbl(hid_t fid, const char *path, double data) 
+{
+  hid_t dataspace_id = H5Screate(H5S_SCALAR);
+  hid_t dataset_id = H5Dcreate2(fid, path, H5IO_FMT_DBL, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, &data);
+  H5Dclose(dataset_id);
+  H5Sclose(dataspace_id);
+}
+
+void h5io_add_data_str(hid_t fid, const char *path, const char *data)
+{
+  hid_t dtype_id = H5Tcopy(H5IO_FMT_STR);
+  H5Tset_size(dtype_id, strlen(data)+1);
+  H5Tset_strpad(dtype_id, H5T_STR_NULLTERM);
+  hid_t dataspace_id = H5Screate(H5S_SCALAR);
+  hid_t dataset_id = H5Dcreate2(fid, path, dtype_id, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Dwrite(dataset_id, dtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+  H5Dclose(dataset_id);
+  H5Sclose(dataspace_id);
+  H5Tclose(dtype_id);
+}
+
+void h5io_add_data_dbl_1d(hid_t fid, const char *path, hsize_t n1, double data[n1])
+{
+  hsize_t dims[1] = { n1 };
+  hid_t dataspace_id = H5Screate_simple(1, dims, NULL);
+  hid_t dataset_id = H5Dcreate2(fid, path, H5IO_FMT_DBL, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+  H5Dclose(dataset_id);
+  H5Sclose(dataspace_id);
+}
+
+void h5io_add_data_dbl_2d(hid_t fid, const char *path, hsize_t n1, hsize_t n2, double data[n1][n2])
+{
+  hsize_t dims[2] = { n1, n2 };
+  hid_t dataspace_id = H5Screate_simple(2, dims, NULL);
+  hid_t dataset_id = H5Dcreate2(fid, path, H5IO_FMT_DBL, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+  H5Dclose(dataset_id);
+  H5Sclose(dataspace_id); 
+}
+
+void h5io_add_data_dbl_3d(hid_t fid, const char *path, hsize_t n1, hsize_t n2, hsize_t n3, double data[n1][n2][n3])
+{
+  hsize_t dims[3] = { n1, n2, n3 };
+  hid_t dataspace_id = H5Screate_simple(3, dims, NULL);
+  hid_t dataset_id = H5Dcreate2(fid, path, H5IO_FMT_DBL, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+  H5Dclose(dataset_id);
+  H5Sclose(dataspace_id); 
+}
+

--- a/h5io.h
+++ b/h5io.h
@@ -1,0 +1,31 @@
+#ifndef H5IO_H
+#define H5IO_H
+
+#define H5IO_FMT_INT (H5T_STD_I32LE)
+#define H5IO_FMT_DBL (H5T_IEEE_F64LE)
+#define H5IO_FMT_STR (H5T_C_S1)
+
+#include <string.h>
+
+#include <hdf5.h>
+
+// groups
+void h5io_add_group(hid_t fid, const char *path);
+
+// attributes
+void h5io_add_attribute_int(hid_t fid, const char *path, const char *name, int attribute);
+void h5io_add_attribute_dbl(hid_t fid, const char *path, const char *name, double attribute);
+void h5io_add_attribute_str(hid_t fid, const char *path, const char *name, const char *attribute);
+
+// data
+void h5io_add_data_int(hid_t fid, const char *path, int data);
+void h5io_add_data_dbl(hid_t fid, const char *path, double data);
+void h5io_add_data_str(hid_t fid, const char *path, const char *data);
+
+void h5io_add_data_dbl_1d(hid_t fid, const char *path, hsize_t n1, double data[n1]);
+void h5io_add_data_dbl_2d(hid_t fid, const char *path, hsize_t n1, hsize_t n2, double data[n1][n2]);
+void h5io_add_data_dbl_3d(hid_t fid, const char *path, hsize_t n1, hsize_t n2, hsize_t n3, double data[n1][n2][n3]);
+
+
+#endif // H5IO_H
+

--- a/machines.py
+++ b/machines.py
@@ -27,30 +27,31 @@ add_machine(name='meade',
 
 add_machine(name='bh',
             compiler='h5pcc',
-            c_flags='-O3 -std=c99 -Wall -fopenmp -g -DVERSION=\"$(GIT_VERSION)\"',
+            c_flags='-O3 -std=c99 -Wall -fopenmp -g',
             l_flags='-lm -lgsl -lgslcblas',
             gsl_dir='')
 
 add_machine(name='bh21',
             compiler='h5pcc',
-            c_flags='-O3 -std=c99 -Wall -fopenmp -g -DVERSION=\"$(GIT_VERSION)\"',
+            c_flags='-O3 -std=c99 -Wall -fopenmp -g',
             l_flags='-lm -lgsl -lgslcblas',
             gsl_dir='')
 
 add_machine(name='bh27',
             compiler='h5pcc',
-            c_flags='-O3 -std=c99 -Wall -fopenmp -g -DVERSION=\"$(GIT_VERSION)\"',
+            c_flags='-O3 -std=c99 -Wall -fopenmp -g',
             l_flags='-lm -lgsl -lgslcblas',
             gsl_dir='')
 
 add_machine(name='lmc',
             compiler='h5pcc',
-            c_flags='-O3 -std=c99 -Wall -fopenmp -g -DVERSION=\"$(GIT_VERSION)\"',
+            c_flags='-O3 -std=c99 -Wall -fopenmp -g',
             l_flags='-lm -lgsl -lgslcblas',
             gsl_dir='')
 
 add_machine(name='stampede2',
             compiler='h5pcc',
-            c_flags='-O3 -std=c99 -Wall -fopenmp -g -DVERSION=\"$(GIT_VERSION)\"',
+            c_flags='-O3 -std=c99 -Wall -fopenmp -g',
             l_flags='-lm -lgsl -lgslcblas',
             gsl_dir='/opt/apps/intel17/gsl/2.3')
+

--- a/main.c
+++ b/main.c
@@ -50,6 +50,7 @@ double F[N_ESAMP + 1], wgt[N_ESAMP + 1];
 int Ns, N_superph_recorded, N_scatt;
 struct of_spectrum spect[N_THBINS][N_EBINS] = { };
 
+double t;
 double a;
 double R0, Rin, Rh, Rout, Rms;
 double hslope;

--- a/model/bhlight2d.c
+++ b/model/bhlight2d.c
@@ -700,9 +700,6 @@ void report_spectrum(int N_superph_made, Params *params)
   h5io_add_data_int(fid, "/params/N2", N2);
   h5io_add_data_int(fid, "/params/N3", N3);
   h5io_add_data_int(fid, "/params/Ns", Ns);
-  h5io_add_data_int(fid, "/params/Nrecorded", N_superph_recorded);
-  h5io_add_data_int(fid, "/params/Nmade", N_superph_made);
-  h5io_add_data_int(fid, "/params/Nscattered", N_scatt);
 
   h5io_add_data_str(fid, "/params/dump", params->dump);
 
@@ -776,6 +773,10 @@ void report_spectrum(int N_superph_made, Params *params)
   h5io_add_data_dbl_2d(fid, "/output/x2av", N_EBINS, N_THBINS, x2av_buf);
   h5io_add_data_dbl_2d(fid, "/output/x3av", N_EBINS, N_THBINS, x3av_buf);
   h5io_add_data_dbl_2d(fid, "/output/nscatt", N_EBINS, N_THBINS, nscatt_buf);
+
+  h5io_add_data_int(fid, "/output/Nrecorded", N_superph_recorded);
+  h5io_add_data_int(fid, "/output/Nmade", N_superph_made);
+  h5io_add_data_int(fid, "/output/Nscattered", N_scatt);
 
   double LEdd = 4. * M_PI * GNEWT * MBH * MP * CL / SIGMA_THOMSON;
   double MdotEdd = 4. * M_PI * GNEWT * MBH * MP / ( SIGMA_THOMSON * CL * 0.1 );

--- a/model/bhlight2d.c
+++ b/model/bhlight2d.c
@@ -641,6 +641,185 @@ void init_data(int argc, char *argv[], Params *params)
 
 //////////////////////////////////// OUTPUT ////////////////////////////////////
 
+#if HDF5_OUTPUT
+void report_spectrum(int N_superph_made, Params *params)
+{
+
+  hid_t fid = -1;
+
+  if (params->loaded && strlen(params->spectrum) > 0) {
+    fid = H5Fcreate(params->spectrum, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  } else {
+    fid = H5Fcreate("spectrum.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  }
+
+  if (fid < 0) {
+    fprintf(stderr, "! unable to open/create hdf5 file.\n");
+    exit(-3);
+  }
+
+  h5io_add_attribute_str(fid, "/", "githash", xstr(VERSION));
+
+  h5io_add_group(fid, "/params");
+
+  h5io_add_data_dbl(fid, "/params/NUCUT", NUCUT);
+  h5io_add_data_dbl(fid, "/params/GAMMACUT", GAMMACUT);
+  h5io_add_data_dbl(fid, "/params/NUMAX", NUMAX);
+  h5io_add_data_dbl(fid, "/params/NUMIN", NUMIN);
+  h5io_add_data_dbl(fid, "/params/LNUMAX", LNUMAX);
+  h5io_add_data_dbl(fid, "/params/LNUMIN", LNUMIN);
+  h5io_add_data_dbl(fid, "/params/DLNU", DLNU);
+  h5io_add_data_dbl(fid, "/params/THETAE_MAX", THETAE_MIN);
+  h5io_add_data_dbl(fid, "/params/THETAE_MIN", THETAE_MAX);
+  h5io_add_data_dbl(fid, "/params/TP_OVER_TE", TP_OVER_TE);
+  h5io_add_data_dbl(fid, "/params/WEIGHT_MIN", WEIGHT_MIN);
+  h5io_add_data_dbl(fid, "/params/KAPPA", KAPPA);
+  h5io_add_data_dbl(fid, "/params/L_unit", L_unit);
+  h5io_add_data_dbl(fid, "/params/T_unit", T_unit);
+  h5io_add_data_dbl(fid, "/params/M_unit", M_unit);
+  h5io_add_data_dbl(fid, "/params/B_unit", B_unit);
+  h5io_add_data_dbl(fid, "/params/Ne_unit", Ne_unit);
+  h5io_add_data_dbl(fid, "/params/RHO_unit", RHO_unit);
+  h5io_add_data_dbl(fid, "/params/U_unit", U_unit);
+  h5io_add_data_dbl(fid, "/params/Thetae_unit", Thetae_unit);
+  h5io_add_data_dbl(fid, "/params/MBH", MBH);
+  h5io_add_data_dbl(fid, "/params/a", a);
+  h5io_add_data_dbl(fid, "/params/Rin", Rin);
+  h5io_add_data_dbl(fid, "/params/Rout", Rout);
+  h5io_add_data_dbl(fid, "/params/hslope", hslope);
+  h5io_add_data_dbl(fid, "/params/t", t);
+
+  h5io_add_data_int(fid, "/params/SYNCHROTRON", SYNCHROTRON);
+  h5io_add_data_int(fid, "/params/BREMSSTRAHLUNG", BREMSSTRAHLUNG);
+  h5io_add_data_int(fid, "/params/COMPTON", COMPTON);
+  h5io_add_data_int(fid, "/params/DIST_KAPPA", DIST_KAPPA);
+  h5io_add_data_int(fid, "/params/N_ESAMP", N_ESAMP);
+  h5io_add_data_int(fid, "/params/N_EBINS", N_EBINS);
+  h5io_add_data_int(fid, "/params/N_THBINS", N_THBINS);
+  h5io_add_data_int(fid, "/params/N1", N1);
+  h5io_add_data_int(fid, "/params/N2", N2);
+  h5io_add_data_int(fid, "/params/N3", N3);
+  h5io_add_data_int(fid, "/params/Ns", Ns);
+  h5io_add_data_int(fid, "/params/Nrecorded", N_superph_recorded);
+  h5io_add_data_int(fid, "/params/Nmade", N_superph_made);
+  h5io_add_data_int(fid, "/params/Nscattered", N_scatt);
+
+  h5io_add_data_str(fid, "/params/dump", params->dump);
+
+  // temporary data buffers
+  double lnu_buf[N_EBINS];
+  double dOmega_buf[N_THBINS];
+  double nuLnu_buf[N_EBINS][N_THBINS];
+  double tau_abs_buf[N_EBINS][N_THBINS];
+  double tau_scatt_buf[N_EBINS][N_THBINS];
+  double x1av_buf[N_EBINS][N_THBINS];
+  double x2av_buf[N_EBINS][N_THBINS];
+  double x3av_buf[N_EBINS][N_THBINS];
+  double nscatt_buf[N_EBINS][N_THBINS];
+
+  // normal output routine
+  double dOmega, nuLnu, tau_scatt, L, nu0, nu1, nu, fnu, dL;
+  double dsource = 8000 * PC;
+
+  max_tau_scatt = 0.;
+  L = 0.;
+  dL = 0.;
+
+  for (int j=0; j<N_THBINS; ++j) {
+    dOmega_buf[j] = 2. * dOmega_func(j);
+  }
+
+  for (int i=0; i<N_EBINS; ++i) {
+    lnu_buf[i] = (i * dlE + lE0) / M_LN10;
+    for (int j=0; j<N_THBINS; ++j) {
+
+      dOmega = 2. * dOmega_func(j);
+
+      nuLnu = (ME * CL * CL) * (4. * M_PI / dOmega) * (1. / dlE);
+      nuLnu *= spect[j][i].dEdlE/LSUN;
+
+      tau_scatt = spect[j][i].tau_scatt/(spect[j][i].dNdlE + SMALL);
+
+      nuLnu_buf[i][j] = nuLnu;
+      tau_abs_buf[i][j] = spect[j][i].tau_abs/(spect[j][i].dNdlE + SMALL);
+      tau_scatt_buf[i][j] = tau_scatt;
+      x1av_buf[i][j] = spect[j][i].X1iav/(spect[j][i].dNdlE + SMALL);
+      x2av_buf[i][j] = sqrt(fabs(spect[j][i].X2isq/(spect[j][i].dNdlE + SMALL)));
+      x3av_buf[i][j] = sqrt(fabs(spect[j][i].X3fsq/(spect[j][i].dNdlE + SMALL)));
+      nscatt_buf[i][j] = spect[j][i].nscatt / (spect[j][i].dNdlE + SMALL);
+
+      if (tau_scatt > max_tau_scatt) max_tau_scatt = tau_scatt;
+
+      dL += ME * CL * CL * spect[j][i].dEdlE;
+      L += nuLnu * dOmega * dlE / (4. * M_PI);
+
+      nu0 = ME * CL * CL * exp((i-0.5) * dlE + lE0) / HPL;
+      nu1 = ME * CL * CL * exp((i+0.5) * dlE + lE0) / HPL;
+
+      if (nu0 < 230.e9 && nu1 > 230.e9) {
+        nu = ME * CL * CL * exp(i * dlE + lE0) / HPL;
+        fnu = nuLnu * LSUN / (4. * M_PI * dsource * dsource * nu * JY);
+        fprintf(stderr, "fnu: %10.5g\n", fnu);
+      }
+
+    }
+  }
+
+  h5io_add_group(fid, "/output");
+
+  h5io_add_data_dbl_1d(fid, "/output/lnu", N_EBINS, lnu_buf);
+  h5io_add_data_dbl_1d(fid, "/output/dOmega", N_THBINS, dOmega_buf);
+  h5io_add_data_dbl_2d(fid, "/output/nuLnu", N_EBINS, N_THBINS, nuLnu_buf);
+  h5io_add_data_dbl_2d(fid, "/output/tau_abs", N_EBINS, N_THBINS, tau_abs_buf);
+  h5io_add_data_dbl_2d(fid, "/output/tau_scatt", N_EBINS, N_THBINS, tau_scatt_buf);
+  h5io_add_data_dbl_2d(fid, "/output/x1av", N_EBINS, N_THBINS, x1av_buf);
+  h5io_add_data_dbl_2d(fid, "/output/x2av", N_EBINS, N_THBINS, x2av_buf);
+  h5io_add_data_dbl_2d(fid, "/output/x3av", N_EBINS, N_THBINS, x3av_buf);
+  h5io_add_data_dbl_2d(fid, "/output/nscatt", N_EBINS, N_THBINS, nscatt_buf);
+
+  double LEdd = 4. * M_PI * GNEWT * MBH * MP * CL / SIGMA_THOMSON;
+  double MdotEdd = 4. * M_PI * GNEWT * MBH * MP / ( SIGMA_THOMSON * CL * 0.1 );
+  double Lum = L * LSUN;
+  double lum = Lum / LEdd;
+  double Mdot = dMact * M_unit / T_unit;
+  double mdot = Mdot / MdotEdd;
+
+  h5io_add_data_dbl(fid, "/output/L", Lum);
+  h5io_add_data_dbl(fid, "/output/Mdot", Mdot);
+  h5io_add_data_dbl(fid, "/output/LEdd", LEdd);
+  h5io_add_data_dbl(fid, "/output/MdotEdd", MdotEdd);
+
+  h5io_add_attribute_str(fid, "/output/L", "units", "erg/s");
+  h5io_add_attribute_str(fid, "/output/LEdd", "units", "erg/s");
+  h5io_add_attribute_str(fid, "/output/Mdot", "units", "g/s");
+  h5io_add_attribute_str(fid, "/output/MdotEdd", "units", "g/s");
+
+  // diagnostic output to screen
+  fprintf(stderr, "\n");
+
+  fprintf(stderr, "MBH = %g Msun\n", MBH/MSUN);
+  fprintf(stderr, "a = %g\n", a);
+
+  fprintf(stderr, "dL = %g\n", dL);
+  fprintf(stderr, "dMact = %g\n", dMact * M_unit / T_unit / (MSUN / YEAR));
+  fprintf(stderr, "efficiency = %g\n", L * LSUN / (dMact * M_unit * CL * CL / T_unit));
+  fprintf(stderr, "L/Ladv = %g\n", L * LSUN / (Ladv * M_unit * CL * CL / T_unit));
+  fprintf(stderr, "max_tau_scatt = %g\n", max_tau_scatt);
+  fprintf(stderr, "Mdot = %g g/s, MdotEdd = %g g/s, mdot = %g MdotEdd\n", Mdot, MdotEdd, mdot);
+  fprintf(stderr, "L = %g erg/s, LEdd = %g erg/s, lum = %g LEdd\n", Lum, LEdd, lum);
+
+  fprintf(stderr, "\n");
+
+  fprintf(stderr, "N_superph_made = %d\n", N_superph_made);
+  fprintf(stderr, "N_superph_scatt = %d\n", N_scatt);
+  fprintf(stderr, "N_superph_recorded = %d\n", N_superph_recorded);
+
+  H5Fclose(fid);
+
+}
+
+#else
+
 #define SPECTRUM_FILE_NAME "spectrum.dat"
 void report_spectrum(int N_superph_made, Params *params)
 {
@@ -738,3 +917,4 @@ void report_spectrum(int N_superph_made, Params *params)
   fclose(fp);
 }
 
+#endif // HDF5_OUTPUT

--- a/model/bhlight2d.h
+++ b/model/bhlight2d.h
@@ -36,3 +36,6 @@
 #define N_EBINS 200
 #define N_THBINS 6
 
+#define HDF5_OUTPUT (0)
+#include "h5io.h"
+

--- a/model/bhlight3d.c
+++ b/model/bhlight3d.c
@@ -694,9 +694,6 @@ void report_spectrum(int N_superph_made, Params *params)
   h5io_add_data_int(fid, "/params/N2", N2);
   h5io_add_data_int(fid, "/params/N3", N3);
   h5io_add_data_int(fid, "/params/Ns", Ns);
-  h5io_add_data_int(fid, "/params/Nrecorded", N_superph_recorded);
-  h5io_add_data_int(fid, "/params/Nmade", N_superph_made);
-  h5io_add_data_int(fid, "/params/Nscattered", N_scatt);
 
   h5io_add_data_str(fid, "/params/dump", params->dump);
 
@@ -770,6 +767,10 @@ void report_spectrum(int N_superph_made, Params *params)
   h5io_add_data_dbl_2d(fid, "/output/x2av", N_EBINS, N_THBINS, x2av_buf);
   h5io_add_data_dbl_2d(fid, "/output/x3av", N_EBINS, N_THBINS, x3av_buf);
   h5io_add_data_dbl_2d(fid, "/output/nscatt", N_EBINS, N_THBINS, nscatt_buf);
+
+  h5io_add_data_int(fid, "/output/Nrecorded", N_superph_recorded);
+  h5io_add_data_int(fid, "/output/Nmade", N_superph_made);
+  h5io_add_data_int(fid, "/output/Nscattered", N_scatt);
 
   double LEdd = 4. * M_PI * GNEWT * MBH * MP * CL / SIGMA_THOMSON;
   double MdotEdd = 4. * M_PI * GNEWT * MBH * MP / ( SIGMA_THOMSON * CL * 0.1 );

--- a/model/bhlight3d.h
+++ b/model/bhlight3d.h
@@ -33,3 +33,6 @@
 #define N_EBINS 200
 #define N_THBINS 6
 
+#define HDF5_OUTPUT (0)
+#include "h5io.h"
+

--- a/model/sphere.c
+++ b/model/sphere.c
@@ -567,9 +567,6 @@ void report_spectrum(int N_superph_made, Params *params)
   h5io_add_data_int(fid, "/params/N2", N2);
   h5io_add_data_int(fid, "/params/N3", N3);
   h5io_add_data_int(fid, "/params/Ns", Ns);
-  h5io_add_data_int(fid, "/params/Nrecorded", N_superph_recorded);
-  h5io_add_data_int(fid, "/params/Nmade", N_superph_made);
-  h5io_add_data_int(fid, "/params/Nscattered", N_scatt);
 
   h5io_add_data_str(fid, "/params/dump", params->dump);
 
@@ -643,6 +640,10 @@ void report_spectrum(int N_superph_made, Params *params)
   h5io_add_data_dbl_2d(fid, "/output/x2av", N_EBINS, N_THBINS, x2av_buf);
   h5io_add_data_dbl_2d(fid, "/output/x3av", N_EBINS, N_THBINS, x3av_buf);
   h5io_add_data_dbl_2d(fid, "/output/nscatt", N_EBINS, N_THBINS, nscatt_buf);
+
+  h5io_add_data_int(fid, "/output/Nrecorded", N_superph_recorded);
+  h5io_add_data_int(fid, "/output/Nmade", N_superph_made);
+  h5io_add_data_int(fid, "/output/Nscattered", N_scatt);
 
   double LEdd = 4. * M_PI * GNEWT * MBH * MP * CL / SIGMA_THOMSON;
   double MdotEdd = 4. * M_PI * GNEWT * MBH * MP / ( SIGMA_THOMSON * CL * 0.1 );

--- a/model/sphere.c
+++ b/model/sphere.c
@@ -508,6 +508,185 @@ void init_data(int argc, char *argv[], Params *params)
 
 //////////////////////////////////// OUTPUT ////////////////////////////////////
 
+#if HDF5_OUTPUT
+void report_spectrum(int N_superph_made, Params *params)
+{
+
+  hid_t fid = -1;
+
+  if (params->loaded && strlen(params->spectrum) > 0) {
+    fid = H5Fcreate(params->spectrum, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  } else {
+    fid = H5Fcreate("spectrum.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  }
+
+  if (fid < 0) {
+    fprintf(stderr, "! unable to open/create hdf5 file.\n");
+    exit(-3);
+  }
+
+  h5io_add_attribute_str(fid, "/", "githash", xstr(VERSION));
+
+  h5io_add_group(fid, "/params");
+
+  h5io_add_data_dbl(fid, "/params/NUCUT", NUCUT);
+  h5io_add_data_dbl(fid, "/params/GAMMACUT", GAMMACUT);
+  h5io_add_data_dbl(fid, "/params/NUMAX", NUMAX);
+  h5io_add_data_dbl(fid, "/params/NUMIN", NUMIN);
+  h5io_add_data_dbl(fid, "/params/LNUMAX", LNUMAX);
+  h5io_add_data_dbl(fid, "/params/LNUMIN", LNUMIN);
+  h5io_add_data_dbl(fid, "/params/DLNU", DLNU);
+  h5io_add_data_dbl(fid, "/params/THETAE_MAX", THETAE_MIN);
+  h5io_add_data_dbl(fid, "/params/THETAE_MIN", THETAE_MAX);
+  h5io_add_data_dbl(fid, "/params/TP_OVER_TE", TP_OVER_TE);
+  h5io_add_data_dbl(fid, "/params/WEIGHT_MIN", WEIGHT_MIN);
+  h5io_add_data_dbl(fid, "/params/KAPPA", KAPPA);
+  h5io_add_data_dbl(fid, "/params/L_unit", L_unit);
+  h5io_add_data_dbl(fid, "/params/T_unit", T_unit);
+  h5io_add_data_dbl(fid, "/params/M_unit", M_unit);
+  h5io_add_data_dbl(fid, "/params/B_unit", B_unit);
+  h5io_add_data_dbl(fid, "/params/Ne_unit", Ne_unit);
+  h5io_add_data_dbl(fid, "/params/RHO_unit", RHO_unit);
+  h5io_add_data_dbl(fid, "/params/U_unit", U_unit);
+  h5io_add_data_dbl(fid, "/params/Thetae_unit", Thetae_unit);
+  h5io_add_data_dbl(fid, "/params/MBH", MBH);
+  h5io_add_data_dbl(fid, "/params/a", a);
+  h5io_add_data_dbl(fid, "/params/Rin", Rin);
+  h5io_add_data_dbl(fid, "/params/Rout", Rout);
+  h5io_add_data_dbl(fid, "/params/hslope", hslope);
+  h5io_add_data_dbl(fid, "/params/t", t);
+
+  h5io_add_data_int(fid, "/params/SYNCHROTRON", SYNCHROTRON);
+  h5io_add_data_int(fid, "/params/BREMSSTRAHLUNG", BREMSSTRAHLUNG);
+  h5io_add_data_int(fid, "/params/COMPTON", COMPTON);
+  h5io_add_data_int(fid, "/params/DIST_KAPPA", DIST_KAPPA);
+  h5io_add_data_int(fid, "/params/N_ESAMP", N_ESAMP);
+  h5io_add_data_int(fid, "/params/N_EBINS", N_EBINS);
+  h5io_add_data_int(fid, "/params/N_THBINS", N_THBINS);
+  h5io_add_data_int(fid, "/params/N1", N1);
+  h5io_add_data_int(fid, "/params/N2", N2);
+  h5io_add_data_int(fid, "/params/N3", N3);
+  h5io_add_data_int(fid, "/params/Ns", Ns);
+  h5io_add_data_int(fid, "/params/Nrecorded", N_superph_recorded);
+  h5io_add_data_int(fid, "/params/Nmade", N_superph_made);
+  h5io_add_data_int(fid, "/params/Nscattered", N_scatt);
+
+  h5io_add_data_str(fid, "/params/dump", params->dump);
+
+  // temporary data buffers
+  double lnu_buf[N_EBINS];
+  double dOmega_buf[N_THBINS];
+  double nuLnu_buf[N_EBINS][N_THBINS];
+  double tau_abs_buf[N_EBINS][N_THBINS];
+  double tau_scatt_buf[N_EBINS][N_THBINS];
+  double x1av_buf[N_EBINS][N_THBINS];
+  double x2av_buf[N_EBINS][N_THBINS];
+  double x3av_buf[N_EBINS][N_THBINS];
+  double nscatt_buf[N_EBINS][N_THBINS];
+
+  // normal output routine
+  double dOmega, nuLnu, tau_scatt, L, nu0, nu1, nu, fnu, dL;
+  double dsource = 8000 * PC;
+
+  max_tau_scatt = 0.;
+  L = 0.;
+  dL = 0.;
+
+  for (int j=0; j<N_THBINS; ++j) {
+    dOmega_buf[j] = 2. * dOmega_func(j);
+  }
+
+  for (int i=0; i<N_EBINS; ++i) {
+    lnu_buf[i] = (i * dlE + lE0) / M_LN10;
+    for (int j=0; j<N_THBINS; ++j) {
+
+      dOmega = 2. * dOmega_func(j);
+
+      nuLnu = (ME * CL * CL) * (4. * M_PI / dOmega) * (1. / dlE);
+      nuLnu *= spect[j][i].dEdlE/LSUN;
+
+      tau_scatt = spect[j][i].tau_scatt/(spect[j][i].dNdlE + SMALL);
+
+      nuLnu_buf[i][j] = nuLnu;
+      tau_abs_buf[i][j] = spect[j][i].tau_abs/(spect[j][i].dNdlE + SMALL);
+      tau_scatt_buf[i][j] = tau_scatt;
+      x1av_buf[i][j] = spect[j][i].X1iav/(spect[j][i].dNdlE + SMALL);
+      x2av_buf[i][j] = sqrt(fabs(spect[j][i].X2isq/(spect[j][i].dNdlE + SMALL)));
+      x3av_buf[i][j] = sqrt(fabs(spect[j][i].X3fsq/(spect[j][i].dNdlE + SMALL)));
+      nscatt_buf[i][j] = spect[j][i].nscatt / (spect[j][i].dNdlE + SMALL);
+
+      if (tau_scatt > max_tau_scatt) max_tau_scatt = tau_scatt;
+
+      dL += ME * CL * CL * spect[j][i].dEdlE;
+      L += nuLnu * dOmega * dlE / (4. * M_PI);
+
+      nu0 = ME * CL * CL * exp((i-0.5) * dlE + lE0) / HPL;
+      nu1 = ME * CL * CL * exp((i+0.5) * dlE + lE0) / HPL;
+
+      if (nu0 < 230.e9 && nu1 > 230.e9) {
+        nu = ME * CL * CL * exp(i * dlE + lE0) / HPL;
+        fnu = nuLnu * LSUN / (4. * M_PI * dsource * dsource * nu * JY);
+        fprintf(stderr, "fnu: %10.5g\n", fnu);
+      }
+
+    }
+  }
+
+  h5io_add_group(fid, "/output");
+
+  h5io_add_data_dbl_1d(fid, "/output/lnu", N_EBINS, lnu_buf);
+  h5io_add_data_dbl_1d(fid, "/output/dOmega", N_THBINS, dOmega_buf);
+  h5io_add_data_dbl_2d(fid, "/output/nuLnu", N_EBINS, N_THBINS, nuLnu_buf);
+  h5io_add_data_dbl_2d(fid, "/output/tau_abs", N_EBINS, N_THBINS, tau_abs_buf);
+  h5io_add_data_dbl_2d(fid, "/output/tau_scatt", N_EBINS, N_THBINS, tau_scatt_buf);
+  h5io_add_data_dbl_2d(fid, "/output/x1av", N_EBINS, N_THBINS, x1av_buf);
+  h5io_add_data_dbl_2d(fid, "/output/x2av", N_EBINS, N_THBINS, x2av_buf);
+  h5io_add_data_dbl_2d(fid, "/output/x3av", N_EBINS, N_THBINS, x3av_buf);
+  h5io_add_data_dbl_2d(fid, "/output/nscatt", N_EBINS, N_THBINS, nscatt_buf);
+
+  double LEdd = 4. * M_PI * GNEWT * MBH * MP * CL / SIGMA_THOMSON;
+  double MdotEdd = 4. * M_PI * GNEWT * MBH * MP / ( SIGMA_THOMSON * CL * 0.1 );
+  double Lum = L * LSUN;
+  double lum = Lum / LEdd;
+  double Mdot = dMact * M_unit / T_unit;
+  double mdot = Mdot / MdotEdd;
+
+  h5io_add_data_dbl(fid, "/output/L", Lum);
+  h5io_add_data_dbl(fid, "/output/Mdot", Mdot);
+  h5io_add_data_dbl(fid, "/output/LEdd", LEdd);
+  h5io_add_data_dbl(fid, "/output/MdotEdd", MdotEdd);
+
+  h5io_add_attribute_str(fid, "/output/L", "units", "erg/s");
+  h5io_add_attribute_str(fid, "/output/LEdd", "units", "erg/s");
+  h5io_add_attribute_str(fid, "/output/Mdot", "units", "g/s");
+  h5io_add_attribute_str(fid, "/output/MdotEdd", "units", "g/s");
+
+  // diagnostic output to screen
+  fprintf(stderr, "\n");
+
+  fprintf(stderr, "MBH = %g Msun\n", MBH/MSUN);
+  fprintf(stderr, "a = %g\n", a);
+
+  fprintf(stderr, "dL = %g\n", dL);
+  fprintf(stderr, "dMact = %g\n", dMact * M_unit / T_unit / (MSUN / YEAR));
+  fprintf(stderr, "efficiency = %g\n", L * LSUN / (dMact * M_unit * CL * CL / T_unit));
+  fprintf(stderr, "L/Ladv = %g\n", L * LSUN / (Ladv * M_unit * CL * CL / T_unit));
+  fprintf(stderr, "max_tau_scatt = %g\n", max_tau_scatt);
+  fprintf(stderr, "Mdot = %g g/s, MdotEdd = %g g/s, mdot = %g MdotEdd\n", Mdot, MdotEdd, mdot);
+  fprintf(stderr, "L = %g erg/s, LEdd = %g erg/s, lum = %g LEdd\n", Lum, LEdd, lum);
+
+  fprintf(stderr, "\n");
+
+  fprintf(stderr, "N_superph_made = %d\n", N_superph_made);
+  fprintf(stderr, "N_superph_scatt = %d\n", N_scatt);
+  fprintf(stderr, "N_superph_recorded = %d\n", N_superph_recorded);
+
+  H5Fclose(fid);
+
+}
+
+#else 
+
 #define SPECTRUM_FILE_NAME "spectrum.dat"
 void report_spectrum(int N_superph_made, Params *params)
 {
@@ -592,3 +771,4 @@ void report_spectrum(int N_superph_made, Params *params)
   fclose(fp);
 }
 
+#endif // HDF5_OUTPUT

--- a/model/sphere.h
+++ b/model/sphere.h
@@ -31,3 +31,6 @@
 #define N_EBINS 200
 #define N_THBINS 3
 
+#define HDF5_OUTPUT (0)
+#include "h5io.h"
+


### PR DESCRIPTION
In this pull request, I introduce an implementation of hdf5 output for the output spectrum data file produced by grmonty. This feature is turned off by default and can be enabled by setting the ```#define HDF5_OUTPUT (1)``` in the desired ```model.h``` header file. This feature should not break legacy scripts.

-----

Included in this pull request:

1. ```h5io.c/h``` files used as a utility to easily add data to an open HDF5 file
2. Modifications to all ```model/*``` files to include a new ```report_spectrum(...)``` function (hidden behind the ```#if HDF5_OUTPUT``` switch) which handles HDF5 output
3. Slight modifications to ```build.py``` and ```machines.py``` scripts to better deal with git version tracking and and pesky issues of quotation mark escaping with h5pcc wrapper

-----

The spectrum file format is as follows:

Two top-level groups exist &ndash; ```/params``` and ```/output```. The former contains all "input" parameters to the program, along with derived quantities which can be easily computed from these input parameters (e.g., L_unit from MBH). It can be thought of as a "header" for the output. The latter group contains all data that the simulation generates as primary output. It can be thought of as all data which requires the dump file to be produced.

path | type | extra information
---|---|---
```/githash``` | string | output of ```$ git describe --dirty --always --tags``` shell command &ndash; useful for version tracking
```/output/dOmega``` | double[][] |
```/output/L``` | double |
```/output/lnu``` | double[] |
```/output/LEdd``` | double |
```/output/Mdot``` | double |
```/output/MdotEdd``` | double |
```/output/Nmade``` | int | 
```/output/Nrecorded``` | int |
```/output/nscatt``` | double[][] |
```/output/Nscattered``` | int |
```/output/nuLnu``` | double[][] |
```/output/tau_abs``` | double[][] |
```/output/tau_scatt``` | double[][] |
```/output/x1av``` | double[][] |
```/output/x2av``` | double[][] |
```/output/x3av``` | double[][] |
```/params/a``` | double |
```/params/B_unit``` | double |
```/params/BREMSSTRAHLUNG``` | int | "do bremsstrahlung" flag
```/params/COMPTON``` | int | "do compton" flag
```/params/DIST_KAPPA``` | int | "use kappa distribution" flag
```/params/DLNU``` | double |
```/params/dump``` | string | input fluid dump filename
```/params/GAMMACUT``` | double |
```/params/hslope``` | double |
```/params/KAPPA``` | double |
```/params/L_unit``` | double |
```/params/NUCUT``` | double | 
```/params/LNUMAX``` | double |
```/params/LNUMIN``` | double |
```/params/M_unit``` | double |
```/params/MBH``` | double |
```/params/N1``` | int |
```/params/N2``` | int |
```/params/N3``` | int |
```/params/N_EBINS``` | int |
```/params/N_ESAMP``` | int |
```/params/N_THBINS``` | int |
```/params/Ne_unit``` | double |
```/params/Ns``` | int |
```/params/NUMAX``` | double |
```/params/NUMIN``` | double |
```/params/RHO_unit``` | double |
```/params/Rin``` | double |
```/params/Rout``` | double |
```/params/SYNCHROTRON``` | int | "do synchrotron" flag
```/params/t``` | double |
```/params/T_unit``` | double |
```/params/THETAE_MAX``` | double |
```/params/THETAE_MIN``` | double |
```/params/Thetae_unit``` | double |
```/params/TP_OVER_TE``` | double |
```/params/U_unit``` | double |
```/params/WEIGHT_MIN``` | double |

